### PR TITLE
refactor: use apps directory as build context

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Build and Push base:${{ env.IMAGE_VERSION }}
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: apps/
           file: apps/_base/${{ github.event.inputs.variant }}/Dockerfile
           push: true
           tags: |

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Build and Push ${{ github.event.inputs.name }}:${{ env.IMAGE_VERSION }}
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: apps/
           file: apps/${{ github.event.inputs.name }}/${{ github.event.inputs.variant }}/Dockerfile
           push: true
           tags: |

--- a/apps/_base/blas-rocm/docker-compose.example.yml
+++ b/apps/_base/blas-rocm/docker-compose.example.yml
@@ -4,8 +4,8 @@ name: example-base
 services:
   blas-rocm:
     build:
-      dockerfile: ./apps/_base/blas-rocm/Dockerfile
-      context: ../../..
+      dockerfile: ./_base/blas-rocm/Dockerfile
+      context: ../..
     image: ghcr.io/futursolo/pai-apps/base:blas-rocm
     devices:
       - /dev/dri:/dev/dri

--- a/apps/_base/pytorch-rocm/Dockerfile
+++ b/apps/_base/pytorch-rocm/Dockerfile
@@ -15,7 +15,7 @@ ARG PYTORCH_ENV_VERSION
 
 RUN python3 -m venv /opt/pytorch-env/
 
-RUN --mount=type=bind,source=./apps/_base/pytorch-rocm/_scripts/,target=/tmp/_build/ \
+RUN --mount=type=bind,source=./_base/pytorch-rocm/_scripts/,target=/tmp/_build/ \
     env \
     PATH="/opt/pytorch-env/bin:$PATH" \
     /tmp/_build/python3.12-install-pytorch-${PYTORCH_ENV_VERSION}.sh

--- a/apps/_base/pytorch-rocm/docker-compose.example.yml
+++ b/apps/_base/pytorch-rocm/docker-compose.example.yml
@@ -4,8 +4,8 @@ name: example-base
 services:
   pytorch-rocm:
     build:
-      dockerfile: ./apps/_base/pytorch-rocm/Dockerfile
-      context: ../../..
+      dockerfile: ./_base/pytorch-rocm/Dockerfile
+      context: ../..
     image: ghcr.io/futursolo/pai-apps/base:pytorch-rocm
     devices:
       - /dev/dri:/dev/dri

--- a/apps/_base/rocm/Dockerfile
+++ b/apps/_base/rocm/Dockerfile
@@ -6,20 +6,20 @@ FROM ubuntu:24.04 AS build-final
 
 ENV TZ=Etc/UTC
 
-RUN  --mount=type=bind,source=./apps/_base/_scripts/,target=/tmp/_build/ \
+RUN  --mount=type=bind,source=./_base/_scripts/,target=/tmp/_build/ \
     /tmp/_build/create-pai-user.sh
 
-RUN  --mount=type=bind,source=./apps/_base/_scripts/,target=/tmp/_build/ \
+RUN  --mount=type=bind,source=./_base/_scripts/,target=/tmp/_build/ \
     --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     /tmp/_build/apt-pre.sh
 
-RUN  --mount=type=bind,source=./apps/_base/_scripts/,target=/tmp/_build/ \
+RUN  --mount=type=bind,source=./_base/_scripts/,target=/tmp/_build/ \
     --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     /tmp/_build/apt-install-python3.sh
 
-RUN  --mount=type=bind,source=./apps/_base/rocm/_scripts/,target=/tmp/_build/ \
+RUN  --mount=type=bind,source=./_base/rocm/_scripts/,target=/tmp/_build/ \
     --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     /tmp/_build/apt-install-rocminfo-deps.sh

--- a/apps/_base/rocm/docker-compose.example.yml
+++ b/apps/_base/rocm/docker-compose.example.yml
@@ -4,8 +4,8 @@ name: example-base
 services:
   rocm:
     build:
-      dockerfile: ./apps/_base/rocm/Dockerfile
-      context: ../../..
+      dockerfile: ./_base/rocm/Dockerfile
+      context: ../..
     image: ghcr.io/futursolo/pai-apps/base:rocm
     devices:
       - /dev/dri:/dev/dri

--- a/apps/comfyui/rocm/Dockerfile
+++ b/apps/comfyui/rocm/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=build-git --chown=root:root /opt/ComfyUI /opt/comfyui
 
 WORKDIR /opt/comfyui
 
-RUN --mount=type=bind,source=./apps/comfyui/_scripts/,target=/tmp/_build/ \
+RUN --mount=type=bind,source=./comfyui/_scripts/,target=/tmp/_build/ \
     /tmp/_build/create-base-tpl.sh
 
 RUN rm -rf .git
@@ -24,7 +24,7 @@ RUN rm -rf .git
 FROM ${PYTORCH_BASE_IMAGE} AS build-comfyui-env
 
 RUN python3 -m venv /opt/comfyui-env/
-RUN --mount=type=bind,source=./apps/_base/_scripts/,target=/tmp/_build/ \
+RUN --mount=type=bind,source=./_base/_scripts/,target=/tmp/_build/ \
     env \
     PATH="/opt/comfyui-env/bin:$PATH" \
     /tmp/_build/python3-link-parent-env.sh /opt/pytorch-env
@@ -41,7 +41,7 @@ COPY --from=build-comfyui /opt/comfyui /opt/comfyui
 COPY --from=build-comfyui /opt/comfyui-base-tpl /opt/comfyui-base-tpl
 COPY --from=build-comfyui-env /opt/comfyui-env /opt/comfyui-env
 
-COPY ./apps/comfyui/_scripts/entrypoint.sh /
+COPY ./comfyui/_scripts/entrypoint.sh /
 
 ENV PATH=/opt/comfyui-env/bin/:/opt/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/apps/comfyui/rocm/docker-compose.example.yml
+++ b/apps/comfyui/rocm/docker-compose.example.yml
@@ -4,8 +4,8 @@ name: example-comfyui
 services:
   comfyui:
     build:
-      dockerfile: ./apps/comfyui/rocm/Dockerfile
-      context: ../../..
+      dockerfile: ./comfyui/rocm/Dockerfile
+      context: ../..
     image: ghcr.io/futursolo/pai-apps/comfyui:rocm
     devices:
       - /dev/dri:/dev/dri

--- a/apps/koboldcpp/rocm/Dockerfile
+++ b/apps/koboldcpp/rocm/Dockerfile
@@ -13,10 +13,10 @@ RUN git clone --depth 1 \
 
 FROM ${ROCM_DEV_IMAGE} AS build-koboldcpp
 
-RUN --mount=type=bind,source=./apps/_base/_scripts/,target=/tmp/_build/ \
+RUN --mount=type=bind,source=./_base/_scripts/,target=/tmp/_build/ \
     /tmp/_build/apt-pre.sh
 
-RUN --mount=type=bind,source=./apps/_base/_scripts/,target=/tmp/_build/ \
+RUN --mount=type=bind,source=./_base/_scripts/,target=/tmp/_build/ \
     /tmp/_build/apt-install-python3-dev.sh
 
 COPY --from=build-git --chown=root:root /opt/koboldcpp-rocm /opt/koboldcpp

--- a/apps/koboldcpp/rocm/docker-compose.example.yml
+++ b/apps/koboldcpp/rocm/docker-compose.example.yml
@@ -4,8 +4,8 @@ name: example-koboldcpp
 services:
   koboldcpp:
     build:
-      dockerfile: ./apps/koboldcpp/rocm/Dockerfile
-      context: ../../..
+      dockerfile: ./koboldcpp/rocm/Dockerfile
+      context: ../..
     image: ghcr.io/futursolo/pai-apps/koboldcpp:rocm
     devices:
       - /dev/dri:/dev/dri


### PR DESCRIPTION
This PR changes the build contexts of images to `apps/`.