### PR TITLE
fix(apps/comfyui/rocm): reference correct base image

### DIFF
--- a/apps/comfyui/rocm/Dockerfile
+++ b/apps/comfyui/rocm/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTORCH_BASE_IMAGE=ghcr.io/futursolo/pai-apps/base:pytorch-v2.8.0-rocm-v6.4.3
+ARG PYTORCH_BASE_IMAGE=ghcr.io/futursolo/pai-apps/base:pytorch-v2.8.0-rocm-v6.4.3-20250823
 ARG COMFYUI_VERSION=v0.3.51
 
 FROM bitnami/git:2.51.0 AS build-git


### PR DESCRIPTION
This fixes the build error where the base image cannot be found.