### PR TITLE
fix(apps/base/pytorch-ipex): run apt pre script before apt

### DIFF
--- a/apps/_base/pytorch-ipex/Dockerfile
+++ b/apps/_base/pytorch-ipex/Dockerfile
@@ -14,6 +14,11 @@ FROM ${INTEL_BASE_IMAGE} AS build-ipex-base
 RUN --mount=type=bind,source=./_base/_scripts/,target=/tmp/_build/ \
     --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    /tmp/_build/apt-pre.sh
+
+RUN --mount=type=bind,source=./_base/_scripts/,target=/tmp/_build/ \
+    --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
     /tmp/_build/apt-install-python3.sh
 
 FROM build-ipex-base AS build-pytorch


### PR DESCRIPTION
This fixes the pytorch-ipex base image build by running apt before apt commands.