### PR TITLE
fix: increase shm size in examples

### DIFF
--- a/apps/comfyui/ipex/docker-compose.example.yml
+++ b/apps/comfyui/ipex/docker-compose.example.yml
@@ -9,6 +9,7 @@ services:
     image: ghcr.io/futursolo/pai-apps/comfyui:ipex
     devices:
       - /dev/dri
+    shm_size: 16G
     environment:
       COMFYUI_LISTEN: 0.0.0.0
     group_add:

--- a/apps/ollama/intel/docker-compose.example.yml
+++ b/apps/ollama/intel/docker-compose.example.yml
@@ -9,6 +9,7 @@ services:
     image: ghcr.io/futursolo/pai-apps/ollama:intel
     devices:
       - /dev/dri
+    shm_size: 16G
     environment:
       - ZES_ENABLE_SYSMAN=1
       - SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1


### PR DESCRIPTION
This PR adds the shm-size to example docker compose.