### PR TITLE
feat(base/apps/blas-rocm): update rocm to v7.0.0

### DIFF
--- a/apps/_base/blas-rocm/.image-version
+++ b/apps/_base/blas-rocm/.image-version
@@ -1,1 +1,1 @@
-blas-rocm-v6.4.3
+blas-rocm-v7.0.0

--- a/apps/_base/blas-rocm/Dockerfile
+++ b/apps/_base/blas-rocm/Dockerfile
@@ -1,5 +1,5 @@
-ARG ROCM_DEV_IMAGE=rocm/dev-ubuntu-24.04:6.4.3-complete
-ARG ROCM_BASE_IMAGE=ghcr.io/futursolo/pai-apps/base:rocm-v6.4.3-20250823
+ARG ROCM_DEV_IMAGE=rocm/dev-ubuntu-24.04:7.0-complete
+ARG ROCM_BASE_IMAGE=ghcr.io/futursolo/pai-apps/base:rocm-v7.0.0-20250927
 
 FROM ${ROCM_DEV_IMAGE} AS build-rocm-blas
 
@@ -8,8 +8,10 @@ RUN cp -av /opt/rocm/lib/libhipblas.so* /opt/rocm-blas-extras/lib/
 RUN cp -av /opt/rocm/lib/librocblas.so* /opt/rocm-blas-extras/lib/
 RUN cp -av /opt/rocm/lib/librocsolver.so* /opt/rocm-blas-extras/lib/
 RUN cp -av /opt/rocm/lib/libhipblaslt.so* /opt/rocm-blas-extras/lib/
+RUN cp -av /opt/rocm/lib/librocroller.so* /opt/rocm-blas-extras/lib/
 
 FROM ${ROCM_BASE_IMAGE} AS build-final
 
 COPY --from=build-rocm-blas /opt/rocm-blas-extras/ /opt/rocm/
 COPY --from=build-rocm-blas /opt/rocm/lib/rocblas/ /opt/rocm/lib/rocblas/
+COPY --from=build-rocm-blas /opt/rocm/lib/hipblaslt/ /opt/rocm/lib/hipblaslt/


### PR DESCRIPTION
This PR updates ROCm to v7.0.0 and includes hipblaslt.