### PR TITLE
fix(apps/base/blas-rocm): install rocm-hip-libraries instead

### DIFF
--- a/apps/_base/blas-rocm/_scripts/apt-install-blas-rocm-deps.sh
+++ b/apps/_base/blas-rocm/_scripts/apt-install-blas-rocm-deps.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-apt-get install -y rocblas hipblaslt
+apt-get install -y --no-install-recommends rocm-hip-libraries


### PR DESCRIPTION
This installs the rocm-hip-libraries instead of hipblaslt and rocblas.