### PR TITLE
fix(apps/base/pytorch-rocm): install miopen

### DIFF
--- a/apps/_base/pytorch-rocm/_scripts/apt-install-pytorch-rocm-deps.sh
+++ b/apps/_base/pytorch-rocm/_scripts/apt-install-pytorch-rocm-deps.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-apt-get install -y libjpeg-dev
+apt-get install -y libjpeg-dev miopen-hip


### PR DESCRIPTION
This installs `miopen-hip` for PyTorch.